### PR TITLE
Use htmlRouteFromJS for deduped HTML bundle routes

### DIFF
--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -245,7 +245,7 @@ pub const AnyRoute = union(enum) {
 
         if (argument.as(Response)) |response_ptr| {
             if (response_ptr.body.value == .Route) {
-                return .{.html = response_ptr.body.value.Route.dupeRef() };
+                return .{ .html = response_ptr.body.value.Route.dupeRef() };
             }
         }
 
@@ -618,6 +618,12 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
         on_clienterror: JSC.Strong.Optional = .empty,
 
         inspector_server_id: JSC.Debugger.DebuggerId = .init(0),
+
+        /// Context used when converting JavaScript values into routes at
+        /// runtime. This keeps track of HTML bundles we've already seen so
+        /// we can reuse the same HTMLBundle.Route across multiple
+        /// responses.
+        init_ctx: AnyRoute.ServerInitContext,
 
         pub const doStop = host_fn.wrapInstanceMethod(ThisServer, "stopFromJS", false);
         pub const dispose = host_fn.wrapInstanceMethod(ThisServer, "disposeFromJS", false);
@@ -1668,6 +1674,11 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                 plugins.deref();
             }
 
+            this.init_ctx.dedupe_html_bundle_map.deinit();
+            this.init_ctx.framework_router_list.deinit();
+            this.init_ctx.js_string_allocations.free();
+            this.init_ctx.arena.deinit();
+
             bun.destroy(this);
         }
 
@@ -1695,7 +1706,18 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
                 .vm = JSC.VirtualMachine.get(),
                 .allocator = Arena.getThreadlocalDefault(),
                 .dev_server = dev_server,
+                // init_ctx will be assigned below
+                .init_ctx = undefined,
             });
+
+            server.init_ctx = .{
+                .arena = .init(bun.default_allocator),
+                .dedupe_html_bundle_map = .init(bun.default_allocator),
+                .js_string_allocations = bun.bake.StringRefList.empty,
+                .global = global,
+                .framework_router_list = std.ArrayList(bun.bake.Framework.FileSystemRouterType).init(bun.default_allocator),
+                .user_routes = &server.config.static_routes,
+            };
 
             if (RequestContext.pool == null) {
                 RequestContext.pool = bun.create(

--- a/src/bun.js/api/server/RequestContext.zig
+++ b/src/bun.js/api/server/RequestContext.zig
@@ -1747,9 +1747,19 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
                         return;
                     };
 
-                    if (route_ptr.data.server == null) {
-                        route_ptr.data.server = AnyServer.from(srv);
+                    var any_route = AnyRoute.htmlRouteFromJS(route_ptr.data.bundle.data.toJS(globalThis), &srv.init_ctx) catch {
+                        globalThis.throwOutOfMemory() catch {};
+                        return;
+                    } orelse AnyRoute{ .html = route_ptr };
+
+                    if (any_route.html.ptr != route_ptr.ptr) {
+                        any_route.ref();
+                        route_ptr.deref();
+                        value.* = .{ .Route = any_route.html.dupeRef() };
+                        route_ptr = any_route.html;
                     }
+
+                    any_route.setServer(AnyServer.from(srv));
 
                     const resp_ptr = this.resp.?;
                     const resp_any = uws.AnyResponse.init(resp_ptr);
@@ -1798,7 +1808,7 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
                         },
                         else => {
                             this.addPendingRoute(route_ptr.data, resp_any, status_code, headers_ref);
-                        }
+                        },
                     }
                     return;
                 },


### PR DESCRIPTION
## Summary
- store `AnyRoute.ServerInitContext` in servers
- deinit server init context resources
- deduplicate HTML routes at render time using `htmlRouteFromJS`

## Testing
- `bun run zig-format` *(fails: FileNotFound)*
- `bun run clang-format` *(fails: command not found)*
- `bun run prettier` *(fails: command not found)*
- `bun bd test test/js/bun/http/serve.test.ts -t "hello"` *(fails: build stopped: subcommand failed)*

------
https://chatgpt.com/codex/tasks/task_e_687d619ce12083308a127d4c18f2b029