### PR TITLE
Implement dynamic dev server start

### DIFF
--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -601,6 +601,14 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             if (server.plugins) |p| {
                 return p.getOrStartLoad(server.globalThis, callback) catch bun.outOfMemory();
             }
+            
+            if (server.vm.transpiler.options.serve_plugins) |serve_plugins_config| {
+                if (serve_plugins_config.len > 0) {
+                    server.plugins = ServePlugins.init(serve_plugins_config);
+                    return server.plugins.?.getOrStartLoad(server.globalThis, callback) catch bun.outOfMemory();
+                }
+            }
+
             // no plugins
             return .{ .ready = null };
         }

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -709,6 +709,7 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             });
             this.dev_server = dev;
             _ = try dev.setRoutes(this);
+            _ = this.getOrLoadPlugins(.{ .dev_server = dev });
             return dev;
         }
 

--- a/src/bun.js/api/server.zig
+++ b/src/bun.js/api/server.zig
@@ -200,7 +200,7 @@ pub const AnyRoute = union(enum) {
 
         if (argument.as(Response)) |response_ptr| {
             if (response_ptr.body.value == .Route) {
-                return .{.html = response_ptr.body.value.Route.dupeRef() };
+                return .{ .html = response_ptr.body.value.Route.dupeRef() };
             }
         }
 
@@ -692,6 +692,24 @@ pub fn NewServer(protocol_enum: enum { http, https }, development_kind: enum { d
             if (this.app) |app| {
                 app.setMaxHTTPHeaderSize(max_header_size);
             }
+        }
+
+        pub fn ensureDevServer(this: *ThisServer) bun.JSOOM!?*bun.bake.DevServer {
+            if (this.dev_server) |dev| return dev;
+            if (!this.config.development.isHMREnabled()) return null;
+
+            const framework = bake.Framework.auto(bun.default_allocator, &this.vm.transpiler.resolver, &.{}) catch return error.OutOfMemory;
+            const dev = try bake.DevServer.init(.{
+                .arena = bun.default_allocator,
+                .root = bun.fs.FileSystem.instance.top_level_dir,
+                .vm = this.vm,
+                .framework = framework,
+                .bundler_options = bake.SplitBundlerOptions.empty,
+                .broadcast_console_log_from_browser_to_server = this.config.broadcast_console_log_from_browser_to_server_for_bake,
+            });
+            this.dev_server = dev;
+            _ = try dev.setRoutes(this);
+            return dev;
         }
 
         pub fn appendStaticRoute(this: *ThisServer, path: []const u8, route: AnyRoute, method: HTTP.Method.Optional) !void {
@@ -3204,6 +3222,16 @@ pub const AnyServer = struct {
             else => bun.unreachablePanic("Invalid pointer tag", .{}),
         };
     }
+
+    pub fn ensureDevServer(this: AnyServer) bun.JSOOM!?*bun.bake.DevServer {
+        return switch (this.ptr.tag()) {
+            Ptr.case(HTTPServer) => this.ptr.as(HTTPServer).ensureDevServer(),
+            Ptr.case(HTTPSServer) => this.ptr.as(HTTPSServer).ensureDevServer(),
+            Ptr.case(DebugHTTPServer) => this.ptr.as(DebugHTTPServer).ensureDevServer(),
+            Ptr.case(DebugHTTPSServer) => this.ptr.as(DebugHTTPSServer).ensureDevServer(),
+            else => bun.unreachablePanic("Invalid pointer tag", .{}),
+        };
+    }
 };
 
 extern fn Bun__addInspector(bool, *anyopaque, *jsc.JSGlobalObject) void;
@@ -3425,3 +3453,4 @@ const Fetch = WebCore.Fetch;
 const Headers = WebCore.Headers;
 const Request = WebCore.Request;
 const Response = WebCore.Response;
+const bake = bun.bake;

--- a/src/bun.js/api/server/RequestContext.zig
+++ b/src/bun.js/api/server/RequestContext.zig
@@ -1752,8 +1752,9 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
                     route_ptr.data.server = server_any;
 
                     if (srv.config.development.isHMREnabled()) {
-                        if (try server_any.ensureDevServer()) |dev| {
-                            bake.DevServer.registerCatchAllHtmlRoute(dev, route_ptr.data) catch bun.outOfMemory();
+                        const dev = server_any.ensureDevServer() catch null;
+                        if (dev) |d| {
+                            bake.DevServer.registerCatchAllHtmlRoute(d, route_ptr.data) catch bun.outOfMemory();
                         } else {
                             const msg = bun.String.static("HMR disabled: register HTMLBundle in `routes` to enable dev server.").toJS(globalThis);
                             jsc.ConsoleObject.messageWithTypeAndLevel(

--- a/src/bun.js/api/server/RequestContext.zig
+++ b/src/bun.js/api/server/RequestContext.zig
@@ -1747,7 +1747,6 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
                         return;
                     };
 
-                    route_ptr.data.server = AnyServer.from(srv);
                     const server_any = AnyServer.from(srv);
                     route_ptr.data.server = server_any;
 

--- a/src/bun.js/api/server/RequestContext.zig
+++ b/src/bun.js/api/server/RequestContext.zig
@@ -1751,18 +1751,20 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
                     const server_any = AnyServer.from(srv);
                     route_ptr.data.server = server_any;
 
-                    if (server_any.devServer()) |dev| {
-                        bake.DevServer.registerCatchAllHtmlRoute(dev, route_ptr.data) catch bun.outOfMemory();
-                    } else if (srv.config.development.isHMREnabled()) {
-                        const msg = bun.String.static("HMR disabled: register HTMLBundle in `routes` to enable dev server.").toJS(globalThis);
-                        jsc.ConsoleObject.messageWithTypeAndLevel(
-                            undefined,
-                            jsc.ConsoleObject.MessageType.Log,
-                            jsc.ConsoleObject.MessageLevel.Warning,
-                            globalThis,
-                            &[_]jsc.JSValue{msg},
-                            1,
-                        );
+                    if (srv.config.development.isHMREnabled()) {
+                        if (try server_any.ensureDevServer()) |dev| {
+                            bake.DevServer.registerCatchAllHtmlRoute(dev, route_ptr.data) catch bun.outOfMemory();
+                        } else {
+                            const msg = bun.String.static("HMR disabled: register HTMLBundle in `routes` to enable dev server.").toJS(globalThis);
+                            jsc.ConsoleObject.messageWithTypeAndLevel(
+                                undefined,
+                                jsc.ConsoleObject.MessageType.Log,
+                                jsc.ConsoleObject.MessageLevel.Warning,
+                                globalThis,
+                                &[_]jsc.JSValue{msg},
+                                1,
+                            );
+                        }
                     }
 
                     const resp_ptr = this.resp.?;


### PR DESCRIPTION
## Summary
- start dev server on demand when an HTML bundle is used
- expose `ensureDevServer` on servers
- register HTML bundle with the newly created dev server

## Testing
- `bun run zig-format src/bun.js/api/server.zig src/bun.js/api/server/RequestContext.zig` *(fails: FileNotFound)*
- `bun run build` *(fails: git error)*

------
https://chatgpt.com/codex/tasks/task_e_6881ec2b5e5c8330a8cafcdc425d3bba