### PR TITLE
Add dev server registration for HTMLBundle routes

### DIFF
--- a/src/bake/DevServer.zig
+++ b/src/bake/DevServer.zig
@@ -2847,9 +2847,13 @@ fn getOrPutRouteBundle(dev: *DevServer, route: RouteBundle.UnresolvedIndex) !Rou
     return bundle_index;
 }
 
-fn registerCatchAllHtmlRoute(dev: *DevServer, html: *HTMLBundle.HTMLBundleRoute) !void {
-    const bundle_index = try getOrPutRouteBundle(dev, .{ .html = html });
-    dev.html_router.fallback = bundle_index.toOptional();
+/// Register an HTMLBundle as the catch-all route for this DevServer.
+///
+/// This is used by `RequestContext` when a handler returns an HTMLBundle
+/// response without having a route defined in `Bun.serve`.
+pub fn registerCatchAllHtmlRoute(dev: *DevServer, html: *HTMLBundle.HTMLBundleRoute) !void {
+    _ = try getOrPutRouteBundle(dev, .{ .html = html });
+    dev.html_router.fallback = html;
 }
 
 const ErrorPageKind = enum {

--- a/src/bun.js/api/server/RequestContext.zig
+++ b/src/bun.js/api/server/RequestContext.zig
@@ -1747,8 +1747,23 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
                         return;
                     };
 
-                    route_ptr.data.server = AnyServer.from(srv);
-                    
+                    const server_any = AnyServer.from(srv);
+                    route_ptr.data.server = server_any;
+
+                    if (server_any.devServer()) |dev| {
+                        bake.DevServer.registerCatchAllHtmlRoute(dev, route_ptr.data) catch bun.outOfMemory();
+                    } else if (srv.config.development.isHMREnabled()) {
+                        const msg = bun.String.static("HMR disabled: register HTMLBundle in `routes` to enable dev server.").toJS(globalThis);
+                        jsc.ConsoleObject.messageWithTypeAndLevel(
+                            undefined,
+                            jsc.ConsoleObject.MessageType.Log,
+                            jsc.ConsoleObject.MessageLevel.Warning,
+                            globalThis,
+                            &[_]jsc.JSValue{msg},
+                            1,
+                        );
+                    }
+
                     const resp_ptr = this.resp.?;
                     const resp_any = uws.AnyResponse.init(resp_ptr);
                     const response = this.response_ptr.?;
@@ -2692,3 +2707,4 @@ const FetchHeaders = jsc.WebCore.FetchHeaders;
 const Request = jsc.WebCore.Request;
 const Response = jsc.WebCore.Response;
 const StaticRoute = @import("./StaticRoute.zig");
+const bake = bun.bake;

--- a/test/js/bun/http/bun-serve-htmlbundle-body-response.test.ts
+++ b/test/js/bun/http/bun-serve-htmlbundle-body-response.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
 import { join } from "path";
 
 const dir = tempDirWithFiles("htmlbundle", {
@@ -85,4 +85,37 @@ test("fetch () => Response(HTMLBundle)", async () => {
   expect(text).toContain("Hello HTML");
   const missing = await fetch(`${server.url}/missing`);
   expect(missing.status).toBe(404);
+});
+
+test("warns when Response(HTMLBundle) returned from fetch without route", async () => {
+  const dir2 = tempDirWithFiles("htmlbundle-warning", {
+    "index.html": "<!DOCTYPE html><html><body>Hello HTML</body></html>",
+    "server.ts": `import html from "./index.html";
+const server = Bun.serve({
+  port: 0,
+  development: true,
+  fetch() {
+    return new Response(html);
+  },
+});
+process.send?.(server.url.toString());`,
+  });
+
+  const { promise, resolve } = Promise.withResolvers<string>();
+  await using proc = Bun.spawn({
+    cwd: dir2,
+    cmd: [bunExe(), "server.ts"],
+    env: bunEnv,
+    stderr: "pipe",
+    ipc(message) {
+      if (typeof message === "string") resolve(message);
+    },
+  });
+
+  const url = await promise;
+  await fetch(url);
+  proc.kill();
+  await proc.exited;
+  const stderr = await proc.stderr.text();
+  expect(stderr).toContain("HMR disabled: register HTMLBundle in `routes` to enable dev server.");
 });

--- a/test/js/bun/http/bun-serve-htmlbundle-warning.fixture.ts
+++ b/test/js/bun/http/bun-serve-htmlbundle-warning.fixture.ts
@@ -1,0 +1,11 @@
+import html from "./index.html";
+
+const server = Bun.serve({
+  port: 0,
+  development: true,
+  fetch() {
+    return new Response(html);
+  },
+});
+
+process.send?.(server.url.toString());


### PR DESCRIPTION
## Summary
- register HTMLBundle routes with the dev server when present
- expose `registerCatchAllHtmlRoute` from DevServer
- warn when HMR is enabled but no dev server exists
- document why the route registration helper is public
- fix fallback assignment in `registerCatchAllHtmlRoute`
- use `devServer()` helper when registering HTMLBundle
- add missing harness imports in tests
- fix dev server check and organize imports

## Testing
- `bun bd test test/js/bun/http/bun-serve-htmlbundle-body-response.test.ts` *(fails: Codex couldn't run certain commands due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_6881b692c80c8330925607411c642e9e