### PR TITLE
Fix HMR catch‑all routing

### DIFF
--- a/src/bake/DevServer.zig
+++ b/src/bake/DevServer.zig
@@ -2847,8 +2847,10 @@ fn getOrPutRouteBundle(dev: *DevServer, route: RouteBundle.UnresolvedIndex) !Rou
 }
 
 pub fn registerCatchAllHtmlRoute(dev: *DevServer, html: *HTMLBundle.HTMLBundleRoute) !void {
-    //const bundle_index = try getOrPutRouteBundle(dev, .{ .html = html });
-    //dev.html_router.fallback = bundle_index.toOptional();
+    if (dev.html_router.fallback != null or dev.html_router.map.get("/") != null) {
+        debug("catch-all HTML route already registered or '/' exists; skipping", .{});
+        return;
+    }
     _ = try getOrPutRouteBundle(dev, .{ .html = html });
     dev.html_router.fallback = html;
 }

--- a/src/bun.js/api/server/RequestContext.zig
+++ b/src/bun.js/api/server/RequestContext.zig
@@ -2523,7 +2523,10 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
                 ctxLog("sendHtmlRoute status={d} method={s}", .{ status_code, @tagName(this.method) });
 
             if (status_code != 200 or headers_ref != null) {
-                var temp = StaticRoute.initFromAnyBlob(&html.blob, .{ .server = html.server, .status_code = status_code, .headers = headers_ref });
+                var temp = StaticRoute.initFromAnyBlob(
+                    &html.blob,
+                    .{ .server = html.server, .status_code = status_code, .headers = headers_ref, .mime_type = &MimeType.html },
+                );
 
                 defer temp.deref();
                 temp.onWithMethod(this.method, resp_any);


### PR DESCRIPTION
## Summary
- ensure `sendHtmlRoute` keeps HTML MIME type
- avoid registering catch‑all HTML route when a root route already exists

## Testing
- `bun run zig-format` *(fails: unable to format GeneratedBindings.zig)*

------
https://chatgpt.com/codex/tasks/task_e_68845004c6648330bbdfbcebf55fd1b1