### PR TITLE
Ensure HTML routes work with dev server

### DIFF
--- a/src/bake/DevServer.zig
+++ b/src/bake/DevServer.zig
@@ -2847,6 +2847,11 @@ fn getOrPutRouteBundle(dev: *DevServer, route: RouteBundle.UnresolvedIndex) !Rou
 }
 
 pub fn registerCatchAllHtmlRoute(dev: *DevServer, html: *HTMLBundle.HTMLBundleRoute) !void {
+    if (dev.html_router.fallback) |_| {
+        Output.warn("DevServer catch-all HTML route already registered", .{});
+        return;
+    }
+
     //const bundle_index = try getOrPutRouteBundle(dev, .{ .html = html });
     //dev.html_router.fallback = bundle_index.toOptional();
     _ = try getOrPutRouteBundle(dev, .{ .html = html });
@@ -3541,7 +3546,10 @@ pub fn routeToBundleIndexSlow(dev: *DevServer, pattern: []const u8) ?RouteBundle
     if (dev.router.matchSlow(pattern, &params)) |route_index| {
         return dev.getOrPutRouteBundle(.{ .framework = route_index }) catch bun.outOfMemory();
     }
-    if (dev.html_router.get(pattern)) |html| {
+    if (dev.html_router.map.get(pattern)) |html| {
+        return dev.getOrPutRouteBundle(.{ .html = html }) catch bun.outOfMemory();
+    }
+    if (dev.html_router.fallback) |html| {
         return dev.getOrPutRouteBundle(.{ .html = html }) catch bun.outOfMemory();
     }
     return null;

--- a/src/bun.js/api/server/RequestContext.zig
+++ b/src/bun.js/api/server/RequestContext.zig
@@ -2522,17 +2522,24 @@ pub fn NewRequestContext(comptime ssl_enabled: bool, comptime debug_mode: bool, 
             if (bun.Environment.enable_logs)
                 ctxLog("sendHtmlRoute status={d} method={s}", .{ status_code, @tagName(this.method) });
 
+            var route_to_send: *StaticRoute = html;
             if (status_code != 200 or headers_ref != null) {
-                var temp = StaticRoute.initFromAnyBlob(&html.blob, .{ .server = html.server, .status_code = status_code, .headers = headers_ref });
-
+                var temp = StaticRoute.initFromAnyBlob(&html.blob, .{
+                    .server = html.server,
+                    .status_code = status_code,
+                    .headers = headers_ref,
+                });
+                route_to_send = temp;
                 defer temp.deref();
-                temp.onWithMethod(this.method, resp_any);
-                if (headers_ref) |h| h.deref();
-            } else if (this.method == .HEAD) {
-                html.onHEAD(resp_any);
-            } else {
-                html.on(resp_any);
             }
+
+            if (this.method == .HEAD) {
+                route_to_send.onHEAD(resp_any);
+            } else {
+                route_to_send.on(resp_any);
+            }
+
+            if (headers_ref) |h| h.deref();
         }
 
         fn addPendingRoute(


### PR DESCRIPTION
## Summary
- always use provided status and headers when sending HTML routes
- don't overwrite existing catch‑all HTML route in dev server
- prefer explicit routes over fallback when resolving HTML bundles

## Testing
- `bun run zig-format` *(fails: unable to format GeneratedBindings.zig)*

------
https://chatgpt.com/codex/tasks/task_e_68845004c6648330bbdfbcebf55fd1b1